### PR TITLE
fix double line number when VTT already include a line number

### DIFF
--- a/examples/subtitles.srt
+++ b/examples/subtitles.srt
@@ -1,4 +1,19 @@
 1
-1
-00:00:01,000 --> 00:00:02,000
-this is WebVTT
+00:11.000 --> 00:13.000 vertical:rl
+We are in New York City
+
+2
+00:13.000 --> 00:16.000
+We're actually at the Lucern Hotel, just down the street
+
+3
+00:16.000 --> 00:18.000
+from the American Museum of Natural History
+
+4
+00:18.000 --> 00:20.000
+And with me is Neil deGrasse Tyson
+
+5
+00:20.000 --> 00:22.000
+Astrophysicist, Director of the Hayden Planetarium

--- a/examples/subtitles.srt
+++ b/examples/subtitles.srt
@@ -1,15 +1,4 @@
 1
-00:11.000 --> 00:13.000 vertical:rl
-We are in New York City
-2
-00:13.000 --> 00:16.000
-We're actually at the Lucern Hotel, just down the street
-3
-00:16.000 --> 00:18.000
-from the American Museum of Natural History
-4
-00:18.000 --> 00:20.000
-And with me is Neil deGrasse Tyson
-5
-00:20.000 --> 00:22.000
-Astrophysicist, Director of the Hayden Planetarium
+1
+00:00:01,000 --> 00:00:02,000
+this is WebVTT

--- a/examples/to_string.js
+++ b/examples/to_string.js
@@ -1,11 +1,12 @@
 /* Convert from a string to a string */
 
-import fs from 'fs';
-import vtt2srt from '..'; // NOTE: replace '..' for 'vtt-to-srt' in your project
+import fs from "fs";
+import vtt2srt from ".."; // NOTE: replace '..' for 'vtt-to-srt' in your project
 
-const vttString = 'WEBVTT FILE\r\n1\r\n00:00:01.000 --> 00:00:02.000\r\nthis is WebVTT';
+const vttString =
+  "WEBVTT FILE\r\n\r\n1\r\n00:00:01.000 --> 00:00:02.000\r\nthis is WebVTT";
 
 const srtStream = vtt2srt();
 
 srtStream.write(vttString);
-srtStream.end(() => console.log(srtStream.read().toString('utf-8')));
+srtStream.end(() => console.log(srtStream.read().toString("utf-8")));

--- a/index.es6
+++ b/index.es6
@@ -1,39 +1,61 @@
-import through from  'through2';
-import split from 'split2';
-import pumpify from 'pumpify';
+import through from "through2";
+import split from "split2";
+import pumpify from "pumpify";
 
-module.exports = function() {
-
+module.exports = function () {
   let count = 0;
+  let currID = null;
+  let blankLine = false;
 
   const write = (line, enc, cb) => {
+    if (!line.trim()) {
+      blankLine = true;
+      return cb();
+    }
 
-      if(!line.trim()) return cb();
+    let vttLine =
+      line
+        .replace(/(WEBVTT\s*(FILE)?.*)(\r\n)*/g, "")
+        .replace(
+          /(\d{2}:\d{2}:\d{2})\.(\d{3}\s+)\-\-\>(\s+\d{2}:\d{2}:\d{2})\.(\d{3}\s*)/g,
+          "$1,$2-->$3,$4"
+        )
+        .replace(/\<.+\>(.+)/g, "$1")
+        .replace(/\<.+\>(.+)\<.+\/\>/g, "$1") + "\r\n";
 
-      let vttLine = line
-      .replace(/(WEBVTT\s*(FILE)?.*)(\r\n)*/g, '')
-      .replace(/(\d{2}:\d{2}:\d{2})\.(\d{3}\s+)\-\-\>(\s+\d{2}:\d{2}:\d{2})\.(\d{3}\s*)/g, '$1,$2-->$3,$4')
-      .replace(/\<.+\>(.+)/g, '$1')
-      .replace(/\<.+\>(.+)\<.+\/\>/g, '$1')+'\r\n';
+    if (!vttLine.trim()) {
+      return cb();
+    }
 
-      if(!vttLine.trim()) return cb();
+    if (/^Kind:|^Language:/m.test(vttLine)) {
+      blankLine = false;
+      return cb();
+    }
 
-      if (/^Kind:|^Language:/m.test(vttLine)) {
-        return cb();
+    if (/^[0-9]+$/m.test(vttLine) && blankLine) {
+      currID = parseInt(vttLine);
+      blankLine = false;
+      return cb();
+    }
+
+    if (/^[0-9]+:/m.test(vttLine)) {
+      if (currID) {
+        vttLine =
+          count++ === 0
+            ? `${currID}\r\n${vttLine}`
+            : `\r\n${currID}\r\n${vttLine}`;
+        currID = null;
+      } else {
+        vttLine =
+          count++ === 0
+            ? `${count}\r\n${vttLine}`
+            : `\r\n${count}\r\n${vttLine}`;
       }
+    }
 
-      if (/^[0-9]+:/m.test(vttLine)) {
-        if (count === 0) {
-          vttLine = `${++count}\r\n${vttLine}`;
-        } else {
-          vttLine = `\r\n${++count}\r\n${vttLine}`;
-        }
-      }
-
-      cb(null, vttLine);
-    
+    blankLine = false;
+    cb(null, vttLine);
   };
 
   return pumpify(split(), through.obj(write));
-
 };

--- a/index.es6
+++ b/index.es6
@@ -4,7 +4,6 @@ import pumpify from "pumpify";
 
 module.exports = function () {
   let count = 0;
-  let currID = null;
   let blankLine = false;
 
   const write = (line, enc, cb) => {
@@ -33,23 +32,15 @@ module.exports = function () {
     }
 
     if (/^[0-9]+$/m.test(vttLine) && blankLine) {
-      currID = parseInt(vttLine);
       blankLine = false;
       return cb();
     }
 
     if (/^[0-9]+:/m.test(vttLine)) {
-      if (currID) {
-        vttLine =
-          count++ === 0
-            ? `${currID}\r\n${vttLine}`
-            : `\r\n${currID}\r\n${vttLine}`;
-        currID = null;
+      if (count === 0) {
+        vttLine = `${++count}\r\n${vttLine}`;
       } else {
-        vttLine =
-          count++ === 0
-            ? `${count}\r\n${vttLine}`
-            : `\r\n${count}\r\n${vttLine}`;
+        vttLine = `\r\n${++count}\r\n${vttLine}`;
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 module.exports = function () {
   var count = 0;
-  var currID = null;
   var blankLine = false;
 
   var write = function write(line, enc, cb) {
@@ -37,17 +36,15 @@ module.exports = function () {
     }
 
     if (/^[0-9]+$/m.test(vttLine) && blankLine) {
-      currID = parseInt(vttLine);
       blankLine = false;
       return cb();
     }
 
     if (/^[0-9]+:/m.test(vttLine)) {
-      if (currID) {
-        vttLine = count++ === 0 ? currID + "\r\n" + vttLine : "\r\n" + currID + "\r\n" + vttLine;
-        currID = null;
+      if (count === 0) {
+        vttLine = ++count + "\r\n" + vttLine;
       } else {
-        vttLine = count++ === 0 ? count + "\r\n" + vttLine : "\r\n" + count + "\r\n" + vttLine;
+        vttLine = "\r\n" + ++count + "\r\n" + vttLine;
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "bin": "cli.js",
   "scripts": {
     "test": "tape test.js",
-    "build": "babel index.es6 > index.js"
+    "build": "babel index.es6 > index.js",
+    "example": "npm run build && babel-node examples/to_string.js"
   },
   "dependencies": {
     "pumpify": "^1.3.3",
@@ -18,6 +19,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.9.1",
+    "babel-node": "0.0.1-security",
     "babel-preset-es2015": "^6.9.0",
     "concat-stream": "^1.4.10",
     "tape": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "tape test.js",
     "build": "babel index.es6 > index.js",
-    "example": "npm run build && babel-node examples/to_string.js"
+    "examples": "npm run build && babel-node examples/to_string.js && babel-node examples/from_file.js"
   },
   "dependencies": {
     "pumpify": "^1.3.3",

--- a/test.js
+++ b/test.js
@@ -1,57 +1,103 @@
 "use strict";
 
-var tape = require('tape');
-var vtt2srt = require('./');
-var concat = require('concat-stream');
+var tape = require("tape");
+var vtt2srt = require("./");
+var concat = require("concat-stream");
 
-tape('empty', function(t) {
-
+tape("empty", function (t) {
   var convert = vtt2srt();
 
   convert.end();
 
-  convert.pipe(concat(function(data) {
+  convert.pipe(
+    concat(function (data) {
+      t.same(data.toString(), "");
 
-    t.same(data.toString(), '');
-
-    t.end();
-
-  }));
-
+      t.end();
+    })
+  );
 });
 
-tape('one entry', function(t) {
-
+tape("one entry", function (t) {
   var convert = vtt2srt();
 
-  convert.write('WEBVTT FILE\r\n\r\n00:00:10.500 --> 00:00:13.000\r\nthis is a test\r\n\r\n');
+  convert.write(
+    "WEBVTT FILE\r\n\r\n00:00:10.500 --> 00:00:13.000\r\nthis is a test\r\n\r\n"
+  );
 
   convert.end();
 
-  convert.pipe(concat(function(data) {
+  convert.pipe(
+    concat(function (data) {
+      t.same(
+        data.toString(),
+        "1\r\n00:00:10,500 --> 00:00:13,000\r\nthis is a test\r\n"
+      );
 
-    t.same(data.toString(), '1\r\n00:00:10,500 --> 00:00:13,000\r\nthis is a test\r\n');
-
-    t.end();
-
-  }));
-
+      t.end();
+    })
+  );
 });
 
-tape('two entries', function(t) {
-
+tape("one entry with line number", function (t) {
   var convert = vtt2srt();
 
-  convert.write('WEBVTT FILE\r\n\r\n00:00:10.500 --> 00:00:13.000\r\nthis is a test\r\n00:00:14.500 --> 00:00:15.000\r\nthis is a test\r\n\r\n');
+  convert.write(
+    "WEBVTT FILE\r\n\r\n1\r\n00:00:10.500 --> 00:00:13.000\r\nthis is a test\r\n\r\n"
+  );
 
   convert.end();
 
-  convert.pipe(concat(function(data) {
+  convert.pipe(
+    concat(function (data) {
+      t.same(
+        data.toString(),
+        "1\r\n00:00:10,500 --> 00:00:13,000\r\nthis is a test\r\n"
+      );
 
-    t.same(data.toString(), '1\r\n00:00:10,500 --> 00:00:13,000\r\nthis is a test\r\n\r\n2\r\n00:00:14,500 --> 00:00:15,000\r\nthis is a test\r\n');
+      t.end();
+    })
+  );
+});
 
-    t.end();
+tape("two entries", function (t) {
+  var convert = vtt2srt();
 
-  }));
+  convert.write(
+    "WEBVTT FILE\r\n\r\n00:00:10.500 --> 00:00:13.000\r\nthis is a test\r\n00:00:14.500 --> 00:00:15.000\r\nthis is a test\r\n\r\n"
+  );
 
+  convert.end();
+
+  convert.pipe(
+    concat(function (data) {
+      t.same(
+        data.toString(),
+        "1\r\n00:00:10,500 --> 00:00:13,000\r\nthis is a test\r\n\r\n2\r\n00:00:14,500 --> 00:00:15,000\r\nthis is a test\r\n"
+      );
+
+      t.end();
+    })
+  );
+});
+
+tape("two entries with line number", function (t) {
+  var convert = vtt2srt();
+
+  convert.write(
+    "WEBVTT FILE\r\n\r\n1\r\n00:00:10.500 --> 00:00:13.000\r\nthis is a test\r\n\r\n2\r\n00:00:14.500 --> 00:00:15.000\r\nthis is a test\r\n\r\n"
+  );
+
+  convert.end();
+
+  convert.pipe(
+    concat(function (data) {
+      t.same(
+        data.toString(),
+        "1\r\n00:00:10,500 --> 00:00:13,000\r\nthis is a test\r\n\r\n2\r\n00:00:14,500 --> 00:00:15,000\r\nthis is a test\r\n"
+      );
+
+      t.end();
+    })
+  );
 });


### PR DESCRIPTION
@anthonygore this PR :
* fix `double` line number bug when VTT already include line number
* add two more test cases that include strings with line numbers
* add a npm script for easy run and build one of examples. `npm run example` for development purpose.
